### PR TITLE
Support URLs when opening paths

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,12 +234,30 @@ function openClipboardPath(openParent) {
         if (!p) return; // 空文字はスキップ
 
         let targetPath = p;
+
+        const isHttpUrl = /^https?:\/\//i.test(targetPath);
+
         if (openParent) {
-            // スラッシュ/バックスラッシュの最後から後ろを切り落とし
-            targetPath = p.replace(/[\\\\/][^\\\\/]*$/, "");
+            if (isHttpUrl) {
+                try {
+                    const u = new URL(targetPath);
+                    u.pathname = u.pathname.replace(/\/[^/]*$/, "");
+                    targetPath = u.toString();
+                } catch (err) {
+                    // URL parsing failed, fall back to original
+                }
+            } else {
+                // スラッシュ/バックスラッシュの最後から後ろを切り落とし
+                targetPath = p.replace(/[\\\\/][^\\\\/]*$/, "");
+            }
         }
 
         if (!targetPath) return;
+
+        if (isHttpUrl) {
+            shell.openExternal(targetPath);
+            return;
+        }
 
         // 存在確認
         if (!fs.existsSync(targetPath)) {


### PR DESCRIPTION
## Summary
- handle http(s) URLs in `openClipboardPath`
- open URLs using `shell.openExternal`
- minor refactor for URL detection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848a35f1508832fb670c37c68642951