### PR TITLE
Add explicit fallback notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ FilePathOpenner は、クリップボードにコピーしたパスをショー�
 - **Clipboard Path Opening**: ショートカットでクリップボード上のパスを開きます。複数行なら改行区切りでそれぞれ開くことも、1 行に結合して開くことも可能です。
 - **Parent Directory Option**: 別のショートカットで 1 階層上のディレクトリ（または URL の親）を開けます。
 - **Input Cleanup**: 前後の空白除去や指定文字の削除など、パス整形オプションを備えます。
+- **Path Fallback**: 指定したパスが存在しない場合、親ディレクトリを自動で開き、
+  元のパスと移動した階層数を知らせます。
 - **Customizable Shortcuts**: 設定画面から開くキーを自由に変更できます。
 - **Tray Minimization**: ウィンドウを閉じてもアプリは終了せず、タスクトレイに常駐します。
 - **Windows Startup Registration**: Windows 環境ではスタートアップフォルダにショートカットを作成・削除できます。

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -22,8 +22,14 @@ jest.unstable_mockModule('electron-store', () => ({
 const electronMock = {
   clipboard: { readText: jest.fn() },
   shell: { openExternal: jest.fn(), openPath: jest.fn() },
-  dialog: { showErrorBox: jest.fn() },
-  app: {}, BrowserWindow: {}, globalShortcut: {}, Menu: {}, Tray: {}, nativeImage: {}, ipcMain: { on: jest.fn(), handle: jest.fn() }
+  dialog: { showErrorBox: jest.fn(), showMessageBox: jest.fn() },
+  app: {},
+  BrowserWindow: {},
+  globalShortcut: {},
+  Menu: {},
+  Tray: {},
+  nativeImage: {},
+  ipcMain: { on: jest.fn(), handle: jest.fn() }
 };
 jest.unstable_mockModule('electron', () => electronMock);
 
@@ -64,12 +70,27 @@ describe('main.js utilities', () => {
     expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/dir');
   });
 
-  test('openClipboardPath shows error for missing path', () => {
+  test('openClipboardPath falls back to existing parent', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     storeData.openAsSinglePath = false;
     storeData.trimSpaces = false;
     storeData.removeList = '';
-    clipboard.readText.mockReturnValue('/not/exist');
+    clipboard.readText.mockReturnValue('/not/exist/file.txt');
+    fs.existsSync.mockImplementation(p => p === '/not/exist');
+    openClipboardPath(false);
+    expect(shell.openPath).toHaveBeenCalledWith('/not/exist');
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'info',
+      message: '"/not/exist/file.txt" は存在しません。1 階層上の "/not/exist" を開きます。'
+    }));
+  });
+
+  test('openClipboardPath shows error when no part exists', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    storeData.openAsSinglePath = false;
+    storeData.trimSpaces = false;
+    storeData.removeList = '';
+    clipboard.readText.mockReturnValue('Z:\\no\\path');
     fs.existsSync.mockReturnValue(false);
     openClipboardPath(false);
     expect(dialog.showErrorBox).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- return levels in `findExistingPath`
- inform users when falling back to a parent directory
- document the enhanced behavior
- expand tests for the new message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848af784094832f90159af0226f090a