### PR TITLE
Switch preload.js to ES modules

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -2,7 +2,7 @@
 // レンダラープロセス(ブラウザWindow)とメインプロセスを安全にやりとりするため
 // (contextIsolation: true の場合、ここで contextBridge を使う)
 
-const { contextBridge, ipcRenderer } = require("electron");
+import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("electronAPI", {
     // 設定を更新して同期的に応答を受け取る


### PR DESCRIPTION
## Summary
- convert `preload.js` to ES module syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684968d35f74832f9855dca86dcb0996