### PR TITLE
Remove exec usage

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -5,7 +5,7 @@ jest.unstable_mockModule('fs', () => ({
     unlink: jest.fn(),
   },
 }));
-jest.unstable_mockModule('child_process', () => ({ exec: jest.fn(), execFile: jest.fn() }));
+jest.unstable_mockModule('child_process', () => ({ execFile: jest.fn() }));
 
 const storeData = {};
 const getMock = jest.fn(key => storeData[key]);
@@ -34,7 +34,6 @@ const electronMock = {
 jest.unstable_mockModule('electron', () => electronMock);
 
 const fs = (await import('fs')).default;
-const { exec } = await import('child_process');
 const { openClipboardPath, checkIfStartupRegistered, unRegisterStartupShortcut } = await import('../main.js');
 const { clipboard, shell, dialog } = electronMock;
 
@@ -57,7 +56,7 @@ describe('main.js utilities', () => {
     clipboard.readText.mockReturnValue('  C:\\Temp  ');
     fs.existsSync.mockReturnValue(true);
     openClipboardPath(false);
-    expect(exec).toHaveBeenCalledWith('start "" "C:\\Temp"');
+    expect(shell.openPath).toHaveBeenCalledWith('C:\\Temp');
   });
 
   test('openClipboardPath opens parent url', () => {

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ import {
 } from "electron";
 import path from "path";
 import fs from "fs";
-import { exec, execFile } from "child_process";
+import { execFile } from "child_process";
 import Store from "electron-store";
 
 // electron-storeで設定を永続化
@@ -302,11 +302,7 @@ function openClipboardPath(openParent) {
                 buttons: ["OK"],
             });
         }
-        if (process.platform === "win32") {
-            exec(`start \"\" \"${finalPath}\"`);
-        } else {
-            shell.openPath(finalPath);
-        }
+        shell.openPath(finalPath);
     });
 }
 


### PR DESCRIPTION
## Summary
- open files using `shell.openPath` instead of spawning `start`
- adjust tests for `shell.openPath`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684968f21e68832f908b29fe659cf259